### PR TITLE
Add include file to support F103 NUCLEO

### DIFF
--- a/stm32xxxx_hal.h
+++ b/stm32xxxx_hal.h
@@ -12,3 +12,7 @@
 #ifdef STM32L476xx
   #include "stm32l4xx_hal.h"
 #endif
+
+#ifdef STM32F103xB
+  #include "stm32f1xx_hal.h"
+#endif


### PR DESCRIPTION
When using F103 NUCLE, include "stm32f1xx_hal.h"